### PR TITLE
ability to remove your address

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -49,9 +49,33 @@ tape('announce', function (t) {
 })
 
 
+tape('remove', function (t) {
+  alice.deviceAddress.announce({
+    address: null,
+    availability: 0
+  }, function (err, msg) {
+    if(err) throw err
+    console.log('published', msg)
+    setTimeout(function (){
+      alice.deviceAddress.getAddress(alice.id, function (err, data) {
+        t.notOk(err)
+        t.notOk(data)
+        t.end()
+      })
+    },1000)
+  })
+})
+
 tape('shutdown', function (t) {
   alice.close()
   t.end()
 })
+
+
+
+
+
+
+
 
 


### PR DESCRIPTION
adds ability to revoke an address by setting `availability: 0`. if you use `deviceAddress.announce --availability 0` it also publishes a null address. only one multiaddress (which can contain multiple server/protocol addresses) per feed.

interprets the message @cryptix published here https://github.com/ssbc/ssb-device-address/issues/4
as he intended.
